### PR TITLE
Replace emoji for wishlist links

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,7 @@ def generate_message_from_trades(available_trades: AvailableTrades, max_message_
         trader = trade_manager.get_trader(discord_id)
         wishlist_url = trader.wishlist_url if trader else None
         if wishlist_url:
-            lines.append(f"{discord_user.mention} [🛍️]({wishlist_url}) has available trades: \n")
+            lines.append(f"{discord_user.mention} ([WL]({wishlist_url})) has available trades: \n")
         else:
             lines.append(f"{discord_user.mention} has available trades: \n")
         cards = available_trades[discord_id]

--- a/src/test/test_main_unit.py
+++ b/src/test/test_main_unit.py
@@ -160,7 +160,7 @@ class TestGenerateMessageFromTrades(unittest.TestCase):
             mock_bot.get_user.return_value = mock_user
             messages = generate_message_from_trades(self._make_trades(discord_id))
 
-        self.assertTrue(any("[🛍️](https://moxfield.com/decks/deck_xyz)" in m for m in messages))
+        self.assertTrue(any("[WL](https://moxfield.com/decks/deck_xyz)" in m for m in messages))
 
     def test_no_wishlist_plain_header(self):
         discord_id = "43"


### PR DESCRIPTION
Discord doesn't allow emojis as masked links for some reason. :(